### PR TITLE
V1.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Supported [fields](https://api.playnite.link/docs/api/Playnite.SDK.Plugins.Metad
 ### Getting metadata directly from the game page
 
 If you can't find the game you're looking for in the search results, you can get the metadata directly from the game page by giving the game's URL.   
-To do this, you need to add a new link to the game with the name `dlsite` and the link's URL.
+To do this, you need to add a new link to the game with the name `dlsite` and the link's URL or directly the work ID (RJ150726).
 
 #### Example
 
@@ -64,7 +64,7 @@ You can configure the plugin by going to the plugin settings and setting the fol
 ## Roadmap
 
 - [x] Add the possibility to fetch metadata from every category at once
-- [ ] Fetch a game by its work ID instead of the full URL
+- [x] Fetch a game by its work ID instead of the full URL
 - [ ] Automatic .pext packaging at every release
 - [ ] Add tests
 

--- a/manifests/InstallerManifest.yaml
+++ b/manifests/InstallerManifest.yaml
@@ -1,12 +1,11 @@
 ﻿AddonId: DLsiteMetadata
 Packages:
-  - Version: 1.1
+  - Version: 1.11
     RequiredApiVersion: 6.11.0
-    ReleaseDate: 2024-09-21
-    PackageUrl: https://github.com/Mysterken/DLsiteMetadata/releases/download/v1.1/DLsiteMetadata_1_1.pext
+    ReleaseDate: 2025-01-11
+    PackageUrl: https://github.com/Mysterken/DLsiteMetadata/releases/download/v1.11/DLsiteMetadata_1_11.pext
     Changelog:
-      - Add option to search from all categories at once
-      - Update extension logo
-      - Update README.md
+      - Add search games directly by its ID instead of the full URL
+      - Fix no games found when a space is in the name
+      - Fix double request when searching with category "All categories"
       - Update dependencies
-      - Restructure and clean code

--- a/source/App.config
+++ b/source/App.config
@@ -3,11 +3,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.1.0" newVersion="6.0.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Encoding.CodePages" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/source/DLsiteMetadata.csproj
+++ b/source/DLsiteMetadata.csproj
@@ -36,11 +36,11 @@
         <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
           <HintPath>packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
         </Reference>
-        <Reference Include="HtmlAgilityPack, Version=1.11.65.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-          <HintPath>packages\HtmlAgilityPack.1.11.65\lib\Net45\HtmlAgilityPack.dll</HintPath>
+        <Reference Include="HtmlAgilityPack, Version=1.11.72.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+          <HintPath>packages\HtmlAgilityPack.1.11.72\lib\Net45\HtmlAgilityPack.dll</HintPath>
         </Reference>
         <Reference Include="JetBrains.Annotations, Version=4242.42.42.42, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-          <HintPath>packages\JetBrains.Annotations.2024.2.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+          <HintPath>packages\JetBrains.Annotations.2024.3.0\lib\net20\JetBrains.Annotations.dll</HintPath>
         </Reference>
         <Reference Include="mscorlib"/>
         <Reference Include="Playnite.SDK, Version=6.11.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -49,22 +49,22 @@
         <Reference Include="PresentationCore"/>
         <Reference Include="PresentationFramework"/>
         <Reference Include="System"/>
-        <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-            <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+        <Reference Include="System.Buffers, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+          <HintPath>packages\System.Buffers.4.6.0\lib\net462\System.Buffers.dll</HintPath>
         </Reference>
         <Reference Include="System.Core"/>
-        <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-          <HintPath>packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+        <Reference Include="System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+          <HintPath>packages\System.Memory.4.6.0\lib\net462\System.Memory.dll</HintPath>
         </Reference>
         <Reference Include="System.Numerics"/>
-        <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-            <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+        <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
         </Reference>
-        <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-            <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+        <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
         </Reference>
-        <Reference Include="System.Text.Encoding.CodePages, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <HintPath>packages\System.Text.Encoding.CodePages.6.0.0\lib\net461\System.Text.Encoding.CodePages.dll</HintPath>
+        <Reference Include="System.Text.Encoding.CodePages, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <HintPath>packages\System.Text.Encoding.CodePages.9.0.0\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
         </Reference>
         <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
             <HintPath>packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>

--- a/source/DLsiteMetadataProvider.cs
+++ b/source/DLsiteMetadataProvider.cs
@@ -228,6 +228,7 @@ public class DLsiteMetadataProvider(
                     if (settings.SearchCategory == "All categories")
                     {
                         var searchTasks = settings.GetAvailableSearchCategory()
+                            .Where(category => category != "All categories")
                             .Select(category => scrapper.ScrapSearchPage(
                                 DLsiteMetadataSettings.GetSearchCategoryPath(category),
                                 query,

--- a/source/DLsiteMetadataProvider.cs
+++ b/source/DLsiteMetadataProvider.cs
@@ -219,6 +219,8 @@ public class DLsiteMetadataProvider(
 
         if (!isValidUrl)
         {
+            var defaultSearch = dlsiteLink != null && DLsiteScrapper.IsValidId(dlsiteLink) ? dlsiteLink : gameName;
+            
             var selectedGame = (DLsiteItemOption)playniteApi.Dialogs.ChooseItemWithSearch(
                 null,
                 query =>
@@ -277,7 +279,7 @@ public class DLsiteMetadataProvider(
                             game => new DLsiteItemOption(game.Title, game.Excerpt, game.Link)
                         ).ToList()
                     ];
-                }, gameName, "Search DLsite");
+                }, defaultSearch, "Search DLsite");
 
             if (selectedGame == null) return;
 

--- a/source/DLsiteScrapper.cs
+++ b/source/DLsiteScrapper.cs
@@ -295,4 +295,10 @@ public class DLsiteScrapper(ILogger logger)
             @"https://www\.dlsite\.com/(home|soft|maniax|pro)/work/=/product_id/(RJ|BJ|VJ)(\d{6}|\d{8})\.html");
         return match.Success;
     }
+    
+    public static bool IsValidId(string id)
+    {
+        var match = Regex.Match(id, @"(RJ|BJ|VJ)(\d{6}|\d{8})$");
+        return match.Success;
+    }
 }

--- a/source/DLsiteScrapper.cs
+++ b/source/DLsiteScrapper.cs
@@ -242,6 +242,8 @@ public class DLsiteScrapper(ILogger logger)
                 "{0}/fsr/=/language/jp/keyword/{1}/age_category[0]/general/work_category[0]/doujin/work_category[1]/pc/work_category[2]/app/order[0]/trend/options_and_or/and/per_page/{2}/show_type/1/from/fs.header/?locale={3}"
         };
 
+        query = query.Replace(" ", "+");
+
         searchUrl = string.Format(searchUrl, searchCategory, query, maxSearchResults, language.ToString());
 
         var client = new HttpClient();

--- a/source/extension.yaml
+++ b/source/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: DLsiteMetadata
 Name: DLsite Metadata Provider
 Author: Mysterken
-Version: 1.1
+Version: 1.11
 Module: DLsiteMetadata.dll
 Type: MetadataProvider
 Icon: Resources\DLsiteLogo.png

--- a/source/packages.config
+++ b/source/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
-  <package id="HtmlAgilityPack" version="1.11.65" targetFramework="net462" />
-  <package id="JetBrains.Annotations" version="2024.2.0" targetFramework="net462" />
+  <package id="HtmlAgilityPack" version="1.11.72" targetFramework="net462" />
+  <package id="JetBrains.Annotations" version="2024.3.0" targetFramework="net462" />
   <package id="PlayniteSDK" version="6.11.0" targetFramework="net462" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
-  <package id="System.Memory" version="4.5.5" targetFramework="net462" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
-  <package id="System.Text.Encoding.CodePages" version="6.0.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.6.0" targetFramework="net462" />
+  <package id="System.Memory" version="4.6.0" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net462" />
+  <package id="System.Text.Encoding.CodePages" version="9.0.0" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Fix some bugs and add a new feature.

Changes:

- Add the possibility to search a game by its work ID instead of the full URL.
- Fix the bug where no games are found if there is a space in the name.
- Fix the double request when using the "All categories" option.
- The dependencies have been upgraded.

---

Explanations:

> Fix the bug where no games are found if there is a space in the name

If a space is in the URL DLsite send back a 403 forbidden so we replace it by a "+"

> Fix the double request when using the "All categories" option

Internally there were two same request made to the `/home` categories of game if "All categories" was chosen