### PR TITLE
V1.13.3

### DIFF
--- a/manifests/InstallerManifest.yaml
+++ b/manifests/InstallerManifest.yaml
@@ -1,5 +1,12 @@
 ﻿AddonId: 'DLsiteMetadata_db03c8d9-645a-4359-aafb-01cda945f301'
 Packages:
+  - Version: 1.13.3
+    RequiredApiVersion: 6.11.0
+    ReleaseDate: 2025-04-11
+    PackageUrl: https://github.com/Mysterken/DLsiteMetadata/releases/download/v1.13.3/DLsiteMetadata_1_13_3.pext
+    Changelog:
+      - Fix multiples author as developers
+      - Fix incorrect date if time included
   - Version: 1.13.2
     RequiredApiVersion: 6.11.0
     ReleaseDate: 2025-03-19

--- a/source/DLsiteScrapper.cs
+++ b/source/DLsiteScrapper.cs
@@ -76,20 +76,24 @@ public class DLsiteScrapper(ILogger logger)
                         case SupportedLanguages.ja_JP:
                         case SupportedLanguages.zh_CN:
                         case SupportedLanguages.zh_TW:
-                            DateTime.TryParseExact(releaseDateString, "yyyy'年'MM'月'dd'日'", CultureInfo.InvariantCulture,
-                                DateTimeStyles.None, out releaseDate);
+                            DateTime.TryParseExact(releaseDateString,
+                                ["yyyy'年'MM'月'dd'日'", "yyyy'年'MM'月'dd'日' H'時'"],
+                                CultureInfo.InvariantCulture, DateTimeStyles.None, out releaseDate);
                             break;
                         case SupportedLanguages.en_US:
-                            DateTime.TryParseExact(releaseDateString, "MMM/dd/yyyy", CultureInfo.InvariantCulture,
-                                DateTimeStyles.None, out releaseDate);
+                            DateTime.TryParseExact(releaseDateString,
+                                ["MMM/dd/yyyy", "MMM/dd/yyyy H"],
+                                CultureInfo.InvariantCulture, DateTimeStyles.None, out releaseDate);
                             break;
                         case SupportedLanguages.ko_KR:
-                            DateTime.TryParseExact(releaseDateString, "yyyy'년 'MM'월 'dd'일'",
+                            DateTime.TryParseExact(releaseDateString,
+                                ["yyyy'년 'MM'월 'dd'일'", "yyyy'년 'MM'월 'dd'일 H'시'"],
                                 CultureInfo.InvariantCulture, DateTimeStyles.None, out releaseDate);
                             break;
                         case SupportedLanguages.es_ES:
-                            DateTime.TryParseExact(releaseDateString, "MM/dd/yyyy", CultureInfo.InvariantCulture,
-                                DateTimeStyles.None, out releaseDate);
+                            DateTime.TryParseExact(releaseDateString,
+                                ["MM/dd/yyyy", "MM/dd/yyyy H"],
+                                CultureInfo.InvariantCulture, DateTimeStyles.None, out releaseDate);
                             break;
                         case SupportedLanguages.de_DE:
                         case SupportedLanguages.fr_FR:
@@ -99,8 +103,9 @@ public class DLsiteScrapper(ILogger logger)
                         case SupportedLanguages.sv_SE:
                         case SupportedLanguages.th_TH:
                         case SupportedLanguages.vi_VN:
-                            DateTime.TryParseExact(releaseDateString, "dd/MM/yyyy", CultureInfo.InvariantCulture,
-                                DateTimeStyles.None, out releaseDate);
+                            DateTime.TryParseExact(releaseDateString,
+                                ["dd/MM/yyyy", "dd/MM/yyyy H"],
+                                CultureInfo.InvariantCulture, DateTimeStyles.None, out releaseDate);
                             break;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(language), language, "Unsupported language");
@@ -183,7 +188,7 @@ public class DLsiteScrapper(ILogger logger)
 
                     continue;
                 }
-                
+
                 if (header.TextContent.Contains(TranslationDictionary.ProductFormat[language]))
                 {
                     result.ProductFormat = header.NextElementSibling?
@@ -192,7 +197,7 @@ public class DLsiteScrapper(ILogger logger)
                         .ToList();
                     continue;
                 }
-                
+
                 if (header.TextContent.Contains(TranslationDictionary.FileFormat[language]))
                 {
                     result.FileFormat = header.NextElementSibling?

--- a/source/DLsiteScrapper.cs
+++ b/source/DLsiteScrapper.cs
@@ -125,7 +125,10 @@ public class DLsiteScrapper(ILogger logger)
 
                 if (header.TextContent.Contains(TranslationDictionary.Author[language]))
                 {
-                    result.Author = header.NextElementSibling?.Text().Trim();
+                    result.Author = header.NextElementSibling?
+                        .QuerySelectorAll("a")
+                        .Select(x => x.Text().Trim())
+                        .ToList();
                     continue;
                 }
 

--- a/source/DLsiteScrapperResult.cs
+++ b/source/DLsiteScrapperResult.cs
@@ -14,7 +14,7 @@ public class DLsiteScrapperResult
     }
 
     [CanBeNull] public AgeRating? Age { get; set; }
-    [CanBeNull] public string Author { get; set; }
+    [CanBeNull] public List<string> Author { get; set; }
     [CanBeNull] public string Circle { get; set; }
     [CanBeNull] public string Description { get; set; }
     [CanBeNull] public List<string> FileFormat { get; set; }

--- a/source/extension.yaml
+++ b/source/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: DLsiteMetadata_db03c8d9-645a-4359-aafb-01cda945f301
 Name: DLsite Metadata Provider
 Author: Mysterken
-Version: 1.13.2
+Version: 1.13.3
 Module: DLsiteMetadata.dll
 Type: MetadataProvider
 Icon: Resources\DLsiteLogo.png


### PR DESCRIPTION
Fix incorrect metadata parsing, see #16 

Changes:

- Fix adding multiples author as developers
- Fix incorrect date if time included

---

Explanation:

> Fix adding multiples author as developers

If multiples author were attributed in the game's page they were merged as one in the developer field.

> Fix incorrect date if time included

Sometimes in the release date of the game, the time is also included which led to the incorrect parsing of the date.