### PR TITLE
Fix rating and original title extraction using DLsite's JSON API

### DIFF
--- a/source/App.config
+++ b/source/App.config
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?><configuration>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/source/DLsiteMetadata.csproj
+++ b/source/DLsiteMetadata.csproj
@@ -1,127 +1,129 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{A54423D1-8E7A-4339-B0D5-24E7CEFE469B}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>DLsiteMetadata</RootNamespace>
-        <AssemblyName>DLsiteMetadata</AssemblyName>
-        <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-        <Deterministic>true</Deterministic>
-        <LangVersion>12</LangVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-          <HintPath>packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
-        </Reference>
-        <Reference Include="HtmlAgilityPack, Version=1.12.0.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
-          <HintPath>packages\HtmlAgilityPack.1.12.0\lib\Net45\HtmlAgilityPack.dll</HintPath>
-        </Reference>
-        <Reference Include="JetBrains.Annotations, Version=4242.42.42.42, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-          <HintPath>packages\JetBrains.Annotations.2024.3.0\lib\net20\JetBrains.Annotations.dll</HintPath>
-        </Reference>
-        <Reference Include="mscorlib"/>
-        <Reference Include="Playnite.SDK, Version=6.11.0.0, Culture=neutral, processorArchitecture=MSIL">
-            <HintPath>packages\PlayniteSDK.6.11.0\lib\net462\Playnite.SDK.dll</HintPath>
-        </Reference>
-        <Reference Include="PresentationCore"/>
-        <Reference Include="PresentationFramework"/>
-        <Reference Include="System"/>
-        <Reference Include="System.Buffers, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-          <HintPath>packages\System.Buffers.4.6.0\lib\net462\System.Buffers.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Core"/>
-        <Reference Include="System.Memory, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-          <HintPath>packages\System.Memory.4.6.1\lib\net462\System.Memory.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Numerics"/>
-        <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <HintPath>packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.1.1\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Text.Encoding.CodePages, Version=9.0.0.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <HintPath>packages\System.Text.Encoding.CodePages.9.0.3\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
-        </Reference>
-        <Reference Include="System.ValueTuple, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-          <HintPath>packages\System.ValueTuple.4.6.0\lib\net462\System.ValueTuple.dll</HintPath>
-        </Reference>
-        <Reference Include="System.Xaml"/>
-        <Reference Include="System.Xml.Linq"/>
-        <Reference Include="System.Data.DataSetExtensions"/>
-        <Reference Include="Microsoft.CSharp"/>
-        <Reference Include="System.Data"/>
-        <Reference Include="System.Net.Http"/>
-        <Reference Include="System.Xml"/>
-        <Reference Include="WindowsBase"/>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="DLsiteItemOption.cs"/>
-        <Compile Include="DLsiteMetadataPlugin.cs"/>
-        <Compile Include="DLsiteMetadataProvider.cs"/>
-        <Compile Include="DLsiteMetadataSettings.cs"/>
-        <Compile Include="DLsiteMetadataSettingsView.xaml.cs">
-            <DependentUpon>DLsiteMetadataSettingsView.xaml</DependentUpon>
-        </Compile>
-        <Compile Include="DLsiteScrapper.cs"/>
-        <Compile Include="DLsiteScrapperResult.cs"/>
-        <Compile Include="Properties\AssemblyInfo.cs"/>
-        <Compile Include="SupportedLanguages.cs"/>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="App.config"/>
-        <None Include="extension.yaml">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <None Include="packages.config"/>
-        <None Include="Resources\DLsiteLogo.png">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="Localization\*.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-        <Page Include="App.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Page>
-        <Page Include="DLsiteMetadataSettingsView.xaml">
-            <Generator>MSBuild:Compile</Generator>
-            <SubType>Designer</SubType>
-        </Page>
-    </ItemGroup>
-    <ItemGroup>
-        <Content Include=".gitignore"/>
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="obj\"/>
-        <Folder Include="Resources\" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A54423D1-8E7A-4339-B0D5-24E7CEFE469B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DLsiteMetadata</RootNamespace>
+    <AssemblyName>DLsiteMetadata</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <LangVersion>12</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=./</PathMap>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
+      <HintPath>packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="HtmlAgilityPack, Version=1.12.0.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>packages\HtmlAgilityPack.1.12.0\lib\Net45\HtmlAgilityPack.dll</HintPath>
+    </Reference>
+    <Reference Include="JetBrains.Annotations, Version=4242.42.42.42, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>packages\JetBrains.Annotations.2024.3.0\lib\net20\JetBrains.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Playnite.SDK, Version=6.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\PlayniteSDK.6.11.0\lib\net462\Playnite.SDK.dll</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Buffers.4.6.0\lib\net462\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.6.1\lib\net462\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.1.1\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=9.0.0.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encoding.CodePages.9.0.3\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.ValueTuple.4.6.0\lib\net462\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DLsiteItemOption.cs" />
+    <Compile Include="DLsiteMetadataPlugin.cs" />
+    <Compile Include="DLsiteMetadataProvider.cs" />
+    <Compile Include="DLsiteMetadataSettings.cs" />
+    <Compile Include="DLsiteMetadataSettingsView.xaml.cs">
+      <DependentUpon>DLsiteMetadataSettingsView.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="DLsiteScrapper.cs" />
+    <Compile Include="DLsiteScrapperResult.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SupportedLanguages.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="extension.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+    <None Include="Resources\DLsiteLogo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Localization\*.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <Page Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="DLsiteMetadataSettingsView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include=".gitignore" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="obj\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/source/DLsiteScrapper.cs
+++ b/source/DLsiteScrapper.cs
@@ -1,14 +1,17 @@
-﻿using System;
+﻿using AngleSharp;
+using AngleSharp.Dom;
+using AngleSharp.Extensions;
+using Newtonsoft.Json.Linq;
+using Playnite.SDK;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using AngleSharp;
-using AngleSharp.Dom;
-using AngleSharp.Extensions;
-using Playnite.SDK;
+using System.Windows.Media;
 
 namespace DLsiteMetadata;
 
@@ -47,11 +50,25 @@ public class DLsiteScrapper(ILogger logger)
         var context = BrowsingContext.New(Configuration.Default);
         var document = await context.OpenAsync(req => req.Content(responseBody));
 
-        var title = document.GetElementById("work_name")?.Text().Trim();
-        result.Title = title;
+        var productIdMatch = Regex.Match(url, @"product_id/([A-Z]{2}\d+)");
+        var productId = productIdMatch.Success ? productIdMatch.Groups[1].Value : null;
 
-        var rating = document.QuerySelector(".point.average_count")?.Text().Trim();
-        result.Rating = float.TryParse(rating, out var parsedRating) ? parsedRating : null;
+        if (!string.IsNullOrEmpty(productId))
+        {
+            var (jsonRating, jsonTitle) = await FetchJsonInfoAsync(productId, language);
+   
+            if (jsonRating.HasValue)
+                result.Rating = (float)jsonRating.Value;
+            if (!string.IsNullOrWhiteSpace(jsonTitle))
+                result.Title = jsonTitle;
+        }
+
+        result.Title ??= document.GetElementById("work_name")?.Text().Trim();
+
+        // Rating is not available in the raw HTML — it's dynamically loaded via JavaScript.
+        // Use JSON API instead for reliable access.
+        //var rating = document.QuerySelector(".point.average_count")?.Text().Trim();
+        //result.Rating = float.TryParse(rating, out var parsedRating) ? parsedRating : null;
 
         var circle = document.QuerySelector("[itemprop='brand']")?.Text().Trim();
         result.Circle = circle;
@@ -289,6 +306,45 @@ public class DLsiteScrapper(ILogger logger)
 
         return searchResults;
     }
+
+    /// Fetches work_name and rating from DLsite's JSON API (uses locale-sensitive data).
+    /// This is more reliable than scraping masked HTML nodes.
+    private async Task<(double? Rating, string WorkName)> FetchJsonInfoAsync(string productId, SupportedLanguages language)
+    {
+        try
+        {
+            var handler = new HttpClientHandler() { UseCookies = true };
+            handler.CookieContainer = new CookieContainer();
+            handler.CookieContainer.Add(new Uri("https://www.dlsite.com"), new Cookie("locale",language.ToString()));
+
+            var client = new HttpClient(handler);
+
+            var url = $"https://www.dlsite.com/maniax/product/info/ajax?product_id={productId}&cdn_cache_min=1";
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36 Edg/136.0.0.0");
+            request.Headers.Referrer = new Uri($"https://www.dlsite.com/maniax/work/=/product_id/{productId}.html?locale={language}");
+            request.Headers.Add("X-Requested-With", "XMLHttpRequest");
+
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+
+            var json = await response.Content.ReadAsStringAsync();
+            var root = JObject.Parse(json);
+            var productNode = root[productId];
+
+            float? rating = productNode["rate_average_2dp"]?.Value<float>();
+            string title = productNode["work_name"]?.Value<string>();
+
+            return (rating, title);
+        }
+        catch (Exception ex)
+        {
+            logger.Warn(ex, $"Failed to fetch JSON data for {productId}");
+            return (null, null);
+        }
+    }
+
 
     private static List<string> ParseImages(IDocument document)
     {

--- a/source/packages.config
+++ b/source/packages.config
@@ -3,6 +3,7 @@
   <package id="AngleSharp" version="0.9.9" targetFramework="net462" />
   <package id="HtmlAgilityPack" version="1.12.0" targetFramework="net462" />
   <package id="JetBrains.Annotations" version="2024.3.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net462" />
   <package id="PlayniteSDK" version="6.11.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.6.0" targetFramework="net462" />
   <package id="System.Memory" version="4.6.1" targetFramework="net462" />


### PR DESCRIPTION
### Summary

This PR replaces the previous method of extracting rating and title from HTML elements, which are often obfuscated or missing, with a more reliable approach using DLsite's internal JSON API.

### Problem

- The HTML element `.point.average_count` used to retrieve the rating is not present in some language versions or not available in the raw HTML.
- Titles can also be masked or replaced depending on user locale or access level.

### Solution

- Use the internal JSON endpoint `product/info/ajax?product_id=...` to fetch `rate_average_2dp` and `work_name`.
- Apply a locale cookie using `HttpClientHandler` and `CookieContainer` to retrieve language-specific results (e.g. `en_US`, `zh_TW`, etc).
- Fallback to HTML-based title only if JSON fails.

### Benefits

- More accurate metadata for rating and title, even under restricted or localized conditions.
- Supports language switching via locale-aware requests.

### Notes

- `Newtonsoft.Json` is used for JSON parsing (added to project references).
- `App.config` was excluded from this PR because only formatting was changed automatically by Visual Studio.

Before: title is masked / rating is null
![before](https://github.com/user-attachments/assets/686c19f7-ea51-4cf7-a361-cbe9d6bf304d)
After: title shows correctly from JSON / rating is 93
![after](https://github.com/user-attachments/assets/abf2086a-b252-40af-85aa-12e949df3b79)

